### PR TITLE
Change escape config

### DIFF
--- a/src/Controller/Component/AltairComponent.php
+++ b/src/Controller/Component/AltairComponent.php
@@ -20,6 +20,7 @@ class AltairComponent extends Component
      * @var string
      */
     private $_charset;
+    private $_double;
 
     /**
      * Default configuration.
@@ -27,7 +28,8 @@ class AltairComponent extends Component
      * @var array
      */
     protected $_defaultConfig = [
-        'charset' => 'UTF-8'
+        'charset' => null,
+        'double' => true
     ];
 
     /**
@@ -39,6 +41,7 @@ class AltairComponent extends Component
     public function initialize(array $config)
     {
         $this->_charset = $this->_config['charset'];
+        $this->_double = $this->_config['double'];
     }
 
     /*
@@ -51,7 +54,8 @@ class AltairComponent extends Component
     {
         $event->subject->helpers += [
             'Altair.Escape' => [
-                'charset' => $this->_charset
+                'charset' => $this->_charset,
+                'double' => $this->_double
             ]
         ];
     }

--- a/src/View/Helper/EscapeHelper.php
+++ b/src/View/Helper/EscapeHelper.php
@@ -18,6 +18,7 @@ class EscapeHelper extends Helper
      * @var string
      */
     private $_charset;
+    private $_double;
 
     /**
      * Default configuration.
@@ -35,8 +36,8 @@ class EscapeHelper extends Helper
     public function __construct(View $view, $config = [])
     {
         parent::__construct($view, $config);
-
         $this->_charset = $this->_config['charset'];
+        $this->_double = $this->_config['double'];
     }
 
 
@@ -86,7 +87,7 @@ class EscapeHelper extends Helper
             return $text;
         }
 
-        return htmlspecialchars($text, ENT_NOQUOTES, $this->_charset);
+        return h($text, $this->_double, $this->_charset);
     }
 
     /**


### PR DESCRIPTION
Change the way to escape.
Use cakephp3.x's h() instead of htmlspecialchars.

``` php
    private function _h($text) {
        if (!is_string($text)) {
            return $text;
        }
        return h($text, $this->_double, $this->_charset);
    }
```
