### PR TITLE
upgraded some lines according to CakePHP 3.6 migration guide

### DIFF
--- a/src/Controller/Component/AltairComponent.php
+++ b/src/Controller/Component/AltairComponent.php
@@ -32,7 +32,7 @@ class AltairComponent extends Component
      */
     public function initialize(array $config)
     {
-        Configure::write('Altair.escape', $this->config('escape'));
+        Configure::write('Altair.escape', $this->getConfig('escape'));
     }
 
     /*
@@ -43,8 +43,8 @@ class AltairComponent extends Component
      */
     public function startup($event)
     {
-        $event->subject->helpers += [
-            'Altair.Escape' => $this->config()
+        $event->getSubject()->helpers += [
+            'Altair.Escape' => $this->getConfig()
         ];
     }
 
@@ -58,8 +58,8 @@ class AltairComponent extends Component
         if (!is_bool($enabled)) {
             return false;
         }
-        $this->config('escape', $enabled);
-        Configure::write('Altair.escape', $this->config('escape'));
+        $this->setConfig('escape', $enabled);
+        Configure::write('Altair.escape', $this->getConfig('escape'));
         return true;
     }
 }

--- a/src/View/Helper/EscapeHelper.php
+++ b/src/View/Helper/EscapeHelper.php
@@ -34,7 +34,7 @@ class EscapeHelper extends Helper
     public function beforeRender($event, $viewFile)
     {
         if(Configure::read('Altair.escape')) {
-            $event->subject->viewVars = $this->automate($event->subject->viewVars);
+            $event->getSubject()->viewVars = $this->automate($event->getSubject()->viewVars);
         }
     }
 


### PR DESCRIPTION
In CakePHP project, many functions and properties were deprecated, and it hurt this plugin, too.
I fixed some codes according to the migration guide 
- https://book.cakephp.org/3.0/en/appendices/3-4-migration-guide.html
- https://book.cakephp.org/3.0/en/appendices/3-5-migration-guide.html

Mainly, I fixed 3 types of codes.
## config()
fixed `config()` function to `getConfig()/setConfig()` function, respectively.
## $subject
![_ _ ___sigfy_](https://user-images.githubusercontent.com/17561419/44707436-77415780-aadf-11e8-8c9b-4af04aa05148.png)
in my product, debug plugin told me Event::$subject was deprecated.

## subject()
3.4 migration guide and my product told me Event::subject() was deprecated. 
![_ _ ___sigfy_](https://user-images.githubusercontent.com/17561419/44707478-9809ad00-aadf-11e8-91af-02558280c700.png)
