### PR TITLE
upgraded deprecations to CakePHP 3.8 migration guide 

### DIFF
--- a/src/View/Helper/EscapeHelper.php
+++ b/src/View/Helper/EscapeHelper.php
@@ -120,7 +120,7 @@ class EscapeHelper extends Helper
         if ($value instanceof Entity) {
             $errors = $value->getErrors();
             $invalid = $value->getInvalid();
-            $properties = $value->visibleProperties();
+            $properties = $value->getVisible();
             foreach ($properties as $prop) {
                 // To not use the entity setter
                 $value->set($prop, $this->escape($value->{$prop}), ['setter' => false]);


### PR DESCRIPTION
I fixed the deprecation according to the migration guide below.

https://book.cakephp.org/3.next/en/appendices/3-8-migration-guide.html#deprecations

The validator seemed irrelevant, I only replacted `EntityTrait::visibleProperties()` to `getVisible()`. 

Actual deprication message is below.

![スクリーンショット 2019-10-02 11 35 18](https://user-images.githubusercontent.com/18255686/66014160-c343a480-e508-11e9-80c4-e18c71ab25b7.png)
